### PR TITLE
Restore history

### DIFF
--- a/Source/PLCrashLogWriterTests.m
+++ b/Source/PLCrashLogWriterTests.m
@@ -271,12 +271,8 @@
 
 - (Plcrash__CrashReport *) loadReport {
     /* Reading the report */
-#pragma clang diagnostic push
-#pragma clang diagnostic warning "-Wdeprecated"
     NSData *data = [NSData dataWithContentsOfFile:_logPath options:NSDataReadingMappedAlways error:nil];
-#pragma clang diagnostic pop
     STAssertNotNil(data, @"Could not map pages");
-
     
     /* Check the file magic. The file must be large enough for the value + version + data */
     const struct PLCrashReportFileHeader *header = [data bytes];

--- a/Source/PLCrashLogWriterTests.m
+++ b/Source/PLCrashLogWriterTests.m
@@ -266,7 +266,7 @@
 
 - (Plcrash__CrashReport *) loadReport {
     /* Reading the report */
-    NSData *data = [NSData dataWithContentsOfMappedFile: _logPath];
+    NSData *data = [NSData dataWithContentsOfFile:_logPath options:NSDataReadingMappedAlways error:nil];
     STAssertNotNil(data, @"Could not map pages");
 
     

--- a/Source/PLCrashReportTests.m
+++ b/Source/PLCrashReportTests.m
@@ -146,7 +146,8 @@ static plcrash_error_t plcr_live_report_callback (plcrash_async_thread_state_t *
     plcrash_async_file_close(&file);
 
     /* Try to parse it */
-    PLCrashReport *crashLog = [[[PLCrashReport alloc] initWithData: [NSData dataWithContentsOfMappedFile: _logPath] error: &error] autorelease];
+    NSData *data = [NSData dataWithContentsOfFile:_logPath options:NSDataReadingMappedIfSafe error:nil];
+    PLCrashReport *crashLog = [[[PLCrashReport alloc] initWithData: data error: &error] autorelease];
     STAssertNotNil(crashLog, @"Could not decode crash log: %@", error);
 
     /* Report info */


### PR DESCRIPTION
We were missing one commit in the develop branch from the official repository. This fixes this and removes the deprecation warning.